### PR TITLE
ci: enforce supply-chain scanning + pre-commit & dependabot gating

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,23 +1,42 @@
-name: 🧪 Audit
+name: 🛡️ Supply Chain
 
+# Runs the supply-chain scanners where they actually matter: every push and PR
+# to `main`, on a weekly schedule (to catch newly-disclosed CVEs against
+# unchanged dependencies), on release, and on demand.
 on:
   push:
-    branches:
-      - feat/qrc
+    branches: [main]
   pull_request:
-    branches:
-      - feat/qrc
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
   release:
     types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  dependencies:
-    name: Audit dependencies
+  audit:
+    name: cargo audit + cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: hecrj/setup-rust-action@v2
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
       - uses: actions/checkout@v4
-      - name: Audit dependencies
-        run: cargo audit
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # RustSec advisory database — fails the build on known CVEs and
+      # annotates the PR with the affected crates.
+      - name: Audit dependencies (RustSec)
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Enforces the existing deny.toml policy (advisories + license allow-list
+      # + banned/duplicate-crate rules) that was previously never run in CI.
+      - name: Enforce supply-chain policy (cargo-deny)
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: 🔀 Dependabot auto-merge
+
+# Dependabot already opens dependency PRs (see .github/dependabot.yml). This
+# gates them: patch/minor bumps are queued for auto-merge once required status
+# checks pass; major bumps are left for manual review. Nothing merges with a
+# red build, because auto-merge respects the repository's required checks.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch & minor updates
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# Pre-commit hooks — block secrets and large files, enforce Rust formatting.
+# Activate once with:  pip install pre-commit && pre-commit install
+# Baseline sweep:       pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files # block accidental binaries/blobs
+        args: ["--maxkb=256"]
+      - id: detect-private-key # block committed private keys
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: check-yaml
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks # secret scanning on the staged diff
+
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt # cargo fmt --check
+      - id: clippy
+        args: ["--all-targets", "--all-features", "--", "-D", "warnings"]

--- a/deny.toml
+++ b/deny.toml
@@ -11,11 +11,11 @@
 # by `image`'s AVIF/EXR codecs, with no upstream fix) are out of our control and
 # would otherwise block every build. Tighten to "all" once upstream cleans up.
 unmaintained = "workspace"
-ignore = [
-    # atty: potential unaligned read (Windows-only), crate unmaintained, no fix
-    # published. Only reachable via a transitive dev/tooling path, not runtime.
-    "RUSTSEC-2021-0145",
-]
+# Note: `atty`/`rand` appear in Cargo.lock but not in the resolved dependency
+# graph (stale lock entries); `cargo update` prunes them and silences the
+# matching cargo-audit warnings. Add RUSTSEC ids here, with justification, only
+# for advisories that genuinely apply to crates we ship.
+ignore = []
 
 [licenses]
 # Deny-by-default: only licenses on this allow-list are accepted. This set

--- a/deny.toml
+++ b/deny.toml
@@ -1,66 +1,52 @@
+# cargo-deny configuration — https://embarkstudios.github.io/cargo-deny
+# Migrated to the cargo-deny 0.16+ schema: the legacy keys (`unlicensed`,
+# `copyleft`, `allow-osi-fsf-free`, license `deny`, and the advisory severity
+# keys) were removed upstream and made the old file fail validation, so the
+# policy was never actually enforced. Both sections are now deny-by-default.
+
+[advisories]
+# RustSec advisory DB. Vulnerabilities and unsound advisories fail the build.
+# `unmaintained = "workspace"` fails only when a crate WE directly depend on is
+# unmaintained — transitive unmaintained crates (e.g. `paste`/`adler` pulled in
+# by `image`'s AVIF/EXR codecs, with no upstream fix) are out of our control and
+# would otherwise block every build. Tighten to "all" once upstream cleans up.
+unmaintained = "workspace"
+ignore = [
+    # atty: potential unaligned read (Windows-only), crate unmaintained, no fix
+    # published. Only reachable via a transitive dev/tooling path, not runtime.
+    "RUSTSEC-2021-0145",
+]
+
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
-
-# List of explicitly allowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-allow = ["MPL-2.0"]
-
-# List of explicitly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-deny = []
-
-# The lint level for licenses considered copyleft
-copyleft = "deny"
-
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will only be approved if it is both OSI-approved *AND* FSF/Free
-# * either - The license will be approved if it is either OSI-approved *OR* FSF/Free
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF/Free
-# * fsf-only - The license will be approved if is FSF/Free *AND NOT* OSI-approved
-# * neither - The license will be denied if is FSF/Free *OR* OSI-approved
-allow-osi-fsf-free = "either"
-
-# The confidence threshold for detecting a license from license text.
-# The higher the value, the more closely the license text must be to the
-# canonical license text of a valid SPDX license file.
-# [possible values: any between 0.0 and 1.0].
+# Deny-by-default: only licenses on this allow-list are accepted. This set
+# covers the permissive licenses present in the dependency tree.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "BSL-1.0",
+    "CC0-1.0",
+]
 confidence-threshold = 0.8
 
 [bans]
-# Lint level for when multiple versions of the same crate are detected
+# Warn (don't fail) on duplicate crate versions — these are transitive and
+# upstream-bound (e.g. bitflags 1.x/2.x via image and ureq).
 multiple-versions = "warn"
-
-# The graph highlighting used when creating dotgraphs for crates
-# with multiple versions
-# * lowest-version - The path to the lowest versioned duplicate is highlighted
-# * simplest-path - The path to the version with the fewest edges is highlighted
-# * all - Both lowest-version and simplest-path are used
 highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
 
-# List of crates that are allowed. Use with care!
-allow = [
-]
-
-# List of crates to deny
-deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-]
-
-# Certain crates/versions that will be skipped when doing duplicate detection.
-skip = [
-]
-
-# Similarly to `skip` allows you to skip certain crates during duplicate detection,
-# unlike skip, it also includes the entire tree of transitive dependencies starting at
-# the specified crate, up to a certain depth, which is by default infinite
-skip-tree = [
-]
-
-
-[advisories]
-ignore = [
-]
+[sources]
+# Reject dependencies from registries or git sources we don't expect.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
## What & why

DevSecOps hygiene pass. Dependency health was already good (no unused direct deps, lockfile committed, Dependabot active) — the real gap was **scanners configured but not running**.

### Findings addressed
- **`audit.yml` was dead**: it triggered only on the stale `feat/qrc` branch, so `cargo audit` never ran on `main` or PRs.
- **`deny.toml` was never enforced**: no workflow invoked `cargo-deny`.
- **No pre-commit gate** for secrets / large files.

### Changes (all forward-moving — no history rewrite, no force-push)
- **`.github/workflows/audit.yml`** — retriggered on push/PR to `main` + weekly cron + release; runs `rustsec/audit-check` (CVEs) **and** `cargo-deny` (enforces `deny.toml`).
- **`.pre-commit-config.yaml`** — blocks files >256 KB and private keys, `gitleaks` secret scan, `cargo fmt`/`clippy` on staged changes.
- **`.github/workflows/dependabot-automerge.yml`** — auto-merges green **patch/minor** dependency PRs; majors stay manual.

### Reviewer notes / not done here
- **CVE baseline**: run `cargo audit` + `cargo deny check` locally to confirm clean — couldn't be asserted from the audit environment.
- **Historical bloat** (`static.files/*`, woff2 in git history) and the **405 KB `bubba.ico`** test fixture were flagged but **not** touched (removing history needs a rewrite; per the agreed safety rules that's out of scope unless explicitly requested).
- For auto-merge to be safe, ensure `test.yml` is a **required status check** in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)