### PR TITLE
feat(payload): structured builders (vCard/Wi-Fi/MeCard/EMVCo)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,3 +151,19 @@ opt-level = 0
 overflow-checks = true
 rpath = false
 strip = false
+
+[[example]]
+name = "vcard"
+path = "examples/vcard.rs"
+
+[[example]]
+name = "wifi"
+path = "examples/wifi.rs"
+
+[[example]]
+name = "mecard"
+path = "examples/mecard.rs"
+
+[[example]]
+name = "emvco"
+path = "examples/emvco.rs"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">QR Code Library (QRC)</h1>
 
 <p align="center">
-  <strong>Generate and manipulate QR code images in PNG, JPG, GIF, and SVG -- built in Rust.</strong>
+  <strong>Generate and style QR codes as PNG, JPG, GIF, and SVG — fast, dependency-light, and 100% safe Rust.</strong>
 </p>
 
 <p align="center">
@@ -22,15 +22,17 @@
 
 ## Contents
 
-- [Install](#install) -- add to Cargo.toml and start generating
-- [Quick Start](#quick-start) -- create a QR code in 4 lines
-- [Overview](#overview) -- what QRC does
-- [Features](#features) -- v0.0.6 capability matrix
-- [Library Usage](#library-usage) -- formats, colours, watermarks, macros
-- [Macros](#macros) -- 11 convenience macros
-- [Examples](#examples) -- 13 focused examples
-- [Development](#development) -- build, test, lint
-- [Security](#security) -- safety guarantees
+- [Install](#install) — add it and start generating
+- [Quick Start](#quick-start) — a QR code in 4 lines
+- [Overview](#overview) — what QRC does
+- [Features](#features) — v0.0.6 capability matrix
+- [Library Usage](#library-usage) — formats, styling, watermarks
+- [Structured Payloads](#structured-payloads) — vCard, Wi-Fi, MeCard, EMVCo
+- [Macros](#macros) — 11 convenience macros
+- [Examples](#examples) — 17 focused examples
+- [Development](#development) — build, test, lint
+- [Security](#security) — safety guarantees
+- [Documentation](#documentation)
 - [License](#license)
 
 ---
@@ -42,6 +44,22 @@
 qrc = "0.0.6"
 ```
 
+…or from the command line:
+
+```bash
+cargo add qrc
+```
+
+### Cargo features
+
+| Feature  | Default | Pulls in                         | Adds                                               |
+| :------- | :-----: | :------------------------------- | :------------------------------------------------- |
+| *(core)* |    ✓    | `image`, `qrcode`, `miniz_oxide` | QR generation, PNG/JPG/GIF/SVG, payloads, macros   |
+| `wasm`   |         | `wasm-bindgen`, `js-sys`         | WebAssembly bindings (`qrc::wasm`) for the browser |
+
+The core API needs **no default features**. The `image` dependency is compiled
+with only the `png`, `jpeg`, `gif`, and `ico` codecs, keeping the tree lean.
+
 ### Build from source
 
 ```bash
@@ -50,7 +68,7 @@ cd qrc
 cargo build --release
 ```
 
-Requires **Rust 1.75.0+**. Tested on Linux, macOS, and Windows.
+Requires **Rust 1.75.0+** (MSRV). Tested on Linux, macOS, and Windows.
 
 ---
 
@@ -59,36 +77,36 @@ Requires **Rust 1.75.0+**. Tested on Linux, macOS, and Windows.
 ```rust
 use qrc::QRCode;
 
-// 1 -- Create a QR code from any string
-let qr = QRCode::from_string("https://example.com".to_string());
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Build a QR code from any string.
+    let qr = QRCode::from_string("https://example.com".to_string());
 
-// 2 -- Export as PNG (512x512)
-let png = qr.to_png(512);
-png.save("qrcode.png").unwrap();
+    // `to_png` returns an `ImageBuffer`, so it has `.save`.
+    qr.to_png(512).save("qrcode.png")?;
 
-// 3 -- Export as SVG (infinite scaling)
-let svg = qr.to_svg(512);
-std::fs::write("qrcode.svg", &svg).unwrap();
+    // `to_svg` returns a `String` — write it yourself (scales infinitely).
+    std::fs::write("qrcode.svg", qr.to_svg(512))?;
 
-// 4 -- Customise with colour
-let coloured = qr.colorize(image::Rgba([0, 102, 204, 255]));
+    Ok(())
+}
 ```
 
 ---
 
 ## Overview
 
-QRC generates QR code images from strings, byte vectors, or raw data. It renders to four image formats, supports colour customisation, watermarking, logo overlays, batch generation, and data compression -- all with zero unsafe code.
+QRC turns strings, byte vectors, or raw data into QR code images. It renders to
+four formats, lets you pick the error-correction level and module shape, and
+ships builders for structured payloads (contacts, Wi-Fi, payments) — all with
+zero `unsafe`.
 
-- **4 output formats** -- PNG, JPG, GIF, SVG
-- **Colour customisation** -- any RGBA colour for dark modules
-- **Image watermarks** -- alpha-blended logos in the corner
-- **Logo overlays** -- centre-placed images on the QR code
-- **Batch generation** -- generate hundreds of QR codes in one call
-- **Multi-language** -- language-aware QR codes from a translation map
-- **Data compression** -- Zlib-compress data before encoding
-- **Dynamic QR codes** -- URL-based codes that can be updated after creation
-- **Zero unsafe code** -- `#![forbid(unsafe_code)]` across the entire codebase
+- **4 output formats** — PNG, JPG, GIF, SVG
+- **Styling** — 4 error-correction levels and 4 module shapes
+- **Structured payloads** — vCard, Wi-Fi, MeCard, EMVCo merchant payments
+- **Colour customisation** — any RGBA colour for dark modules
+- **Watermarks & overlays** — corner watermark or centre logo
+- **Batch generation** — many codes in one call
+- **Zero unsafe code** — `#![forbid(unsafe_code)]` crate-wide
 
 ---
 
@@ -96,30 +114,18 @@ QRC generates QR code images from strings, byte vectors, or raw data. It renders
 
 | | |
 | :--- | :--- |
-| **Formats** | PNG, JPG, GIF (raster via `image` crate), SVG (vector via `qrcode` crate) |
-| **Colours** | Custom RGBA colour for dark modules, white background |
-| **Watermarks** | Alpha-blended watermark placement in bottom-right corner |
-| **Overlays** | Centre-placed logo overlay on any QR code |
-| **Resizing** | Arbitrary width/height scaling with pixel-level control |
-| **Compression** | Zlib compression via `miniz_oxide` (level 6) |
-| **Batch** | Generate a `Vec<QRCode>` from a `Vec<String>` in one call |
-| **Combine** | Merge multiple QR codes side-by-side into a single image |
-| **Dynamic** | URL-based QR codes for post-creation updates |
-| **Multi-language** | HashMap-driven language selection with BCP 47 codes |
-| **Encoding** | UTF-8 encoding format with validation |
-| **Macros** | 11 convenience macros for every operation |
+| **Formats** | PNG, JPG, GIF (raster via `image`), SVG (vector via `qrcode`) |
+| **Error correction** | `EcLevel::{L, M, Q, H}` via `with_ec_level` (default `M`) |
+| **Module shapes** | `ModuleShape::{Square, RoundedSquare, Circle, Diamond}` via `with_shape` |
+| **Payloads** | `payload::{vcard, wifi, mecard, emvco}` — dependency-free string builders |
+| **Colours** | Custom RGBA dark modules on a white background |
+| **Watermarks / Overlays** | Alpha-blended corner watermark; centre logo overlay |
+| **Resizing** | Arbitrary width/height scaling |
+| **Batch / Combine** | `Vec<String>` → `Vec<QRCode>`; merge codes side-by-side |
+| **Macros** | 11 convenience macros |
 | **Safety** | `#![forbid(unsafe_code)]`, `#![deny(missing_docs)]` |
 | **MSRV** | Rust 1.75.0 |
-| **Dependencies** | 3 runtime (`image`, `qrcode`, `miniz_oxide`) |
-
-### Metrics
-
-| Metric | Value |
-| :--- | :--- |
-| **Test suite** | 16 unit tests + 14 doc-tests |
-| **Examples** | 13 focused examples |
-| **Benchmarks** | 7 Criterion benchmarks |
-| **Dependencies** | 3 runtime, 1 dev |
+| **Runtime deps** | 3 (`image`, `qrcode`, `miniz_oxide`) |
 
 ---
 
@@ -130,25 +136,40 @@ QRC generates QR code images from strings, byte vectors, or raw data. It renders
 
 ```rust
 use qrc::QRCode;
-use image::DynamicImage;
 
-let qr = QRCode::from_string("https://docs.rs/qrc".to_string());
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let qr = QRCode::from_string("https://docs.rs/qrc".to_string());
 
-// PNG -- lossless, web-ready
-let png = qr.to_png(512);
-png.save("qrcode.png").unwrap();
+    // `to_png` / `to_image` return an `ImageBuffer` → use `.save`.
+    qr.to_png(512).save("qrcode.png")?;
 
-// JPG -- convert RGBA to RGB for JPEG compatibility
-let jpg = qr.to_jpg(512);
-DynamicImage::ImageRgba8(jpg).to_rgb8().save("qrcode.jpg").unwrap();
+    // `to_jpg` / `to_gif` return ALREADY-ENCODED bytes (`Vec<u8>`) → write them.
+    std::fs::write("qrcode.jpg", qr.to_jpg(512))?;
+    std::fs::write("qrcode.gif", qr.to_gif(512))?;
 
-// GIF -- small palette, universal
-let gif = qr.to_gif(512);
-gif.save("qrcode.gif").unwrap();
+    // `to_svg` returns a `String`.
+    std::fs::write("qrcode.svg", qr.to_svg(512))?;
 
-// SVG -- vector, infinite scaling
-let svg = qr.to_svg(512);
-std::fs::write("qrcode.svg", &svg).unwrap();
+    Ok(())
+}
+```
+
+</details>
+
+<details>
+<summary><b>Pick error-correction level and module shape</b></summary>
+
+```rust
+use qrc::{QRCode, EcLevel, ModuleShape};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let qr = QRCode::from_string("https://example.com".to_string())
+        .with_ec_level(EcLevel::H)        // ~30% recovery — best for logos/print
+        .with_shape(ModuleShape::Circle); // Square | RoundedSquare | Circle | Diamond
+
+    qr.to_png(512).save("styled.png")?;
+    Ok(())
+}
 ```
 
 </details>
@@ -160,9 +181,13 @@ std::fs::write("qrcode.svg", &svg).unwrap();
 use qrc::QRCode;
 use image::Rgba;
 
-let qr = QRCode::from_string("https://example.com".to_string());
-let blue_qr = qr.colorize(Rgba([0, 102, 204, 255]));
-blue_qr.save("blue_qrcode.png").unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let qr = QRCode::from_string("https://example.com".to_string());
+
+    // `colorize` returns an `RgbaImage` → use `.save`.
+    qr.colorize(Rgba([0, 102, 204, 255])).save("blue_qrcode.png")?;
+    Ok(())
+}
 ```
 
 </details>
@@ -174,13 +199,16 @@ blue_qr.save("blue_qrcode.png").unwrap();
 use qrc::QRCode;
 use image::{ImageBuffer, Rgba};
 
-let qr = QRCode::from_string("https://example.com".to_string());
-let mut img = qr.to_png(512);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut img = QRCode::from_string("https://example.com".to_string()).to_png(512);
 
-// Create a 20x20 red logo
-let logo = ImageBuffer::from_fn(20, 20, |_, _| Rgba([220, 20, 60, 255]));
-QRCode::add_image_watermark(&mut img, &logo);
-img.save("watermarked.png").unwrap();
+    // A 20×20 crimson logo, alpha-blended into the corner.
+    let logo = ImageBuffer::from_fn(20, 20, |_, _| Rgba([220, 20, 60, 255]));
+    QRCode::add_image_watermark(&mut img, &logo);
+
+    img.save("watermarked.png")?;
+    Ok(())
+}
 ```
 
 </details>
@@ -191,93 +219,122 @@ img.save("watermarked.png").unwrap();
 ```rust
 use qrc::QRCode;
 
-let urls = vec![
-    "https://example.com/1".to_string(),
-    "https://example.com/2".to_string(),
-    "https://example.com/3".to_string(),
-];
-let codes = QRCode::batch_generate_qr_codes(urls);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let urls = vec![
+        "https://example.com/1".to_string(),
+        "https://example.com/2".to_string(),
+    ];
 
-for (i, qr) in codes.iter().enumerate() {
-    qr.to_png(256).save(format!("qr_{i}.png")).unwrap();
+    for (i, qr) in QRCode::batch_generate_qr_codes(urls).iter().enumerate() {
+        qr.to_png(256).save(format!("qr_{i}.png"))?;
+    }
+    Ok(())
 }
 ```
 
 </details>
 
-<details>
-<summary><b>Compress data before encoding</b></summary>
+---
+
+## Structured Payloads
+
+`qrc::payload` builds the exact text conventions scanners act on — so a scan
+offers "Add to Contacts" or "Join Wi-Fi" instead of showing raw text. The
+builders are plain strings with no extra dependencies.
 
 ```rust
 use qrc::QRCode;
+use qrc::payload::vcard::BusinessCard;
+use qrc::payload::wifi::{WifiNetwork, WifiSecurity};
 
-let data = "A very long string that benefits from compression...";
-let compressed = QRCode::compress_data(data);
-let qr = QRCode::from_bytes(compressed);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Contact card (RFC 6350 / vCard 3.0).
+    let card = BusinessCard::new("Jane Doe")
+        .organization("Acme, Inc.")
+        .title("CEO")
+        .email("jane@acme.example")
+        .url("https://acme.example");
+    QRCode::from_string(card.to_vcard()).to_png(512).save("contact.png")?;
+
+    // Wi-Fi join code.
+    let wifi = WifiNetwork::new("Acme Guest")
+        .security(WifiSecurity::Wpa)
+        .password("hunter2");
+    QRCode::from_string(wifi.to_qr_string()).to_png(512).save("wifi.png")?;
+
+    Ok(())
+}
 ```
 
-</details>
+| Builder | Module | Emits |
+| :--- | :--- | :--- |
+| `BusinessCard` | `payload::vcard` | RFC 6350 vCard 3.0 |
+| `WifiNetwork` | `payload::wifi` | `WIFI:` join string |
+| `MeCard` | `payload::mecard` | Compact contact |
+| `MerchantPayment` | `payload::emvco` | EMVCo MPM + CRC-16/CCITT |
 
 ---
 
 ## Macros
 
-11 convenience macros for every QRC operation:
+11 convenience macros for common operations:
 
 | Macro | Description |
 | :--- | :--- |
 | `qr_code!(data)` | Create a new QR code |
 | `qr_code_to!(data, format, width)` | Create in a specific format (png/jpg/gif) |
-| `add_image_watermark!(img, watermark)` | Add a watermark to a QR code image |
-| `resize!(qrcode, size)` | Resize a QR code to square dimensions |
+| `add_image_watermark!(img, watermark)` | Add a watermark to a QR image |
+| `resize!(qrcode, size)` | Resize to square dimensions |
 | `set_encoding_format!(qr, format)` | Set the encoding format |
 | `overlay_image!(qr, image)` | Overlay a logo at the centre |
 | `batch_generate_qr!(data_list)` | Generate multiple QR codes |
 | `compress_data_macro!(data)` | Compress data via Zlib |
-| `combine_qr_codes!(codes)` | Combine multiple QR codes side-by-side |
+| `combine_qr_codes!(codes)` | Combine codes side-by-side |
 | `create_dynamic_qr!(data)` | Create a dynamic (URL-based) QR code |
 | `create_multilanguage_qr!("en" => "Hello", ...)` | Multi-language QR code |
 
-See the [macros example](examples/macros.rs) for detailed usage.
+See the [`macros` example](examples/macros.rs) for full usage.
 
 ---
 
 ## Examples
 
-Run any example:
-
 ```bash
 cargo run --example basic
-cargo run --example formats
+cargo run --example vcard
 ```
 
 | Example | Purpose |
 | :--- | :--- |
-| `basic` | QR code construction from bytes, strings, and vectors |
-| `formats` | Export to PNG, JPG, GIF, and SVG with file size comparison |
-| `colorize` | Apply custom RGBA colours to QR code modules |
-| `resize` | Resize QR codes for print, web, and thumbnail use cases |
-| `watermark` | Add watermark logos with alpha blending |
-| `overlay` | Centre-place a logo on a QR code |
-| `compress` | Zlib-compress data before QR encoding |
-| `batch` | Generate multiple QR codes from a URL list |
-| `combine` | Merge multiple QR codes into a single image |
+| `basic` | Construction from bytes, strings, and vectors |
+| `formats` | Export to PNG, JPG, GIF, and SVG |
+| `colorize` | Custom RGBA module colours |
+| `resize` | Print, web, and thumbnail sizing |
+| `watermark` | Alpha-blended watermark logos |
+| `overlay` | Centre-placed logo |
+| `compress` | Zlib-compress data before encoding |
+| `batch` | Generate many codes from a URL list |
+| `combine` | Merge codes into one image |
 | `encoding` | Set and validate encoding formats |
-| `dynamic` | Create dynamic QR codes with updatable URLs |
-| `multilingual` | Language-aware QR codes from a translation map |
-| `macros` | Demonstrate all 11 convenience macros |
+| `dynamic` | Updatable URL-based codes |
+| `multilingual` | Language-aware codes from a translation map |
+| `macros` | All 11 convenience macros |
+| `vcard` | vCard contact card |
+| `wifi` | Wi-Fi join code |
+| `mecard` | Compact MeCard contact |
+| `emvco` | EMVCo merchant payment |
 
 ---
 
 ## Development
 
 ```bash
-cargo build               # build the library
-cargo test                 # run all tests (16 unit + 14 doc-tests)
+cargo build                # build the library
+cargo test                 # unit, integration, and doc-tests
 cargo clippy --all-targets # lint with Clippy
 cargo fmt --all            # format with rustfmt
-cargo bench                # run Criterion benchmarks
-cargo xtask ci             # full CI pipeline (fmt + clippy + test)
+cargo bench                # Criterion benchmarks
+cargo xtask ci             # full local CI (fmt + clippy + test)
 ```
 
 ### CI
@@ -285,8 +342,8 @@ cargo xtask ci             # full CI pipeline (fmt + clippy + test)
 | Workflow | Trigger | Purpose |
 | :--- | :--- | :--- |
 | `ci.yml` | push, PR | fmt, clippy, test (3 OS), MSRV, cargo-deny, security audit |
-| `document.yml` | push to main | Build and deploy API docs to GitHub Pages |
-| `release.yml` | tag `v*` | Cross-platform binaries (21 targets), crates.io publish |
+| `document.yml` | push to `main` | Build and deploy API docs |
+| `release.yml` | tag `v*` | Cross-platform binaries, crates.io publish |
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for PR guidelines.
 
@@ -294,17 +351,17 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for PR guidelines.
 
 ## Security
 
-<details>
-<summary><b>Safety guarantees</b></summary>
-
 - `#![forbid(unsafe_code)]` across the entire codebase
-- `#![deny(missing_docs)]` -- every public item is documented
-- `cargo audit` with zero advisories
-- `cargo deny` -- license, advisory, and ban checks in CI
+- `#![deny(missing_docs)]` — every public item is documented
+- `cargo audit` (RustSec) and `cargo deny` (licenses, advisories, bans) in CI
 - SPDX license headers on all source files
-- 3 runtime dependencies -- minimal attack surface
+- 3 runtime dependencies — minimal attack surface
 
-</details>
+---
+
+## Documentation
+
+Full API reference: **[docs.rs/qrc](https://docs.rs/qrc)**.
 
 ---
 

--- a/examples/emvco.rs
+++ b/examples/emvco.rs
@@ -1,0 +1,25 @@
+//! Element: EMVCo merchant-payment payloads — `MerchantAccount` /
+//! `MerchantPayment` (TLV + CRC-16/CCITT).
+//!
+//! Run: `cargo run --example emvco`
+
+use qrc::payload::emvco::{MerchantAccount, MerchantPayment};
+use qrc::QRCode;
+
+fn main() {
+    let account = MerchantAccount::new(26, "com.example.pay").merchant_id("12345678");
+
+    // Dynamic payment (with amount).
+    let dynamic = MerchantPayment::new(account.clone(), "840", "US", "Acme Coffee", "Springfield")
+        .category_code("5814")
+        .amount("4.50");
+    println!("dynamic: {}", dynamic.to_emvco());
+
+    // Static payment (no amount — payer enters it).
+    let static_payment = MerchantPayment::new(account, "840", "US", "Acme Coffee", "Springfield");
+    println!("static:  {}", static_payment.to_emvco());
+
+    assert!(QRCode::from_string(dynamic.to_emvco())
+        .try_to_qrcode()
+        .is_ok());
+}

--- a/examples/mecard.rs
+++ b/examples/mecard.rs
@@ -1,0 +1,25 @@
+//! Element: MeCard contact payloads — `MeCard`.
+//!
+//! Run: `cargo run --example mecard`
+
+use qrc::payload::mecard::MeCard;
+use qrc::QRCode;
+
+fn main() {
+    let card = MeCard::new("Doe,Jane")
+        .reading("doe,jane")
+        .phone("+1-555-0100")
+        .email("jane@acme.example")
+        .url("https://acme.example")
+        .address("1 Market St")
+        .birthday("19900101")
+        .note("hi there");
+    println!("{}", card.to_mecard());
+
+    let minimal = MeCard::new("Solo");
+    println!("minimal: {}", minimal.to_mecard());
+
+    assert!(QRCode::from_string(card.to_mecard())
+        .try_to_qrcode()
+        .is_ok());
+}

--- a/examples/vcard.rs
+++ b/examples/vcard.rs
@@ -1,0 +1,24 @@
+//! Element: vCard business-card payloads — `BusinessCard`.
+//!
+//! Run: `cargo run --example vcard`
+
+use qrc::payload::vcard::BusinessCard;
+use qrc::QRCode;
+
+fn main() {
+    let card = BusinessCard::new("Jane Doe")
+        .name("Jane", "Doe")
+        .organization("Acme, Inc.")
+        .title("CEO")
+        .phone("+1-555-0100")
+        .email("jane@acme.example")
+        .url("https://acme.example")
+        .address("1 Market Street")
+        .note("Scan to add me");
+    println!("{}", card.to_vcard());
+
+    // Only the formatted name is required.
+    println!("\nminimal:\n{}", BusinessCard::new("Solo").to_vcard());
+
+    assert!(QRCode::from_string(card.to_vcard()).try_to_qrcode().is_ok());
+}

--- a/examples/wifi.rs
+++ b/examples/wifi.rs
@@ -1,0 +1,25 @@
+//! Element: Wi-Fi join payloads — `WifiNetwork` / `WifiSecurity`.
+//!
+//! Run: `cargo run --example wifi`
+
+use qrc::payload::wifi::{WifiNetwork, WifiSecurity};
+use qrc::QRCode;
+
+fn main() {
+    // WPA network with a password, hidden SSID.
+    let wpa = WifiNetwork::new("Cafe; Guest")
+        .security(WifiSecurity::Wpa)
+        .password("p@ss,word")
+        .hidden(true);
+    println!("WPA:  {}", wpa.to_qr_string()); // special chars are escaped
+
+    // Open network (the password is omitted).
+    let open = WifiNetwork::new("Free WiFi").security(WifiSecurity::None);
+    println!("Open: {}", open.to_qr_string());
+
+    // Encodes like any string.
+    assert!(QRCode::from_string(wpa.to_qr_string())
+        .try_to_qrcode()
+        .is_ok());
+    println!("encodable: yes");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,10 @@ pub use qrcode::types::QrError;
 /// The `macros` module contains functions for generating macros.
 pub mod macros;
 
+/// Structured payload builders (vCard, Wi-Fi, MeCard, EMVCo) that turn typed
+/// data into the text conventions QR scanners recognise.
+pub mod payload;
+
 #[cfg(feature = "wasm")]
 /// WASM bindings for the QRC library.
 pub mod wasm;

--- a/src/payload/emvco.rs
+++ b/src/payload/emvco.rs
@@ -1,0 +1,169 @@
+// Copyright © 2022-2026 QR Code Library (QRC). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! EMVCo Merchant-Presented Mode (MPM) payment payloads.
+//!
+//! Builds the TLV-encoded, CRC-checked string defined by the
+//! [EMVCo QR Code Specification for Payment Systems (MPM)][emvco] that banking
+//! apps scan to pay a merchant. Field values are assumed to be ASCII and under
+//! 100 characters (the spec's two-digit length).
+//!
+//! ```
+//! use qrc::payload::emvco::{MerchantAccount, MerchantPayment};
+//! use qrc::QRCode;
+//!
+//! let account = MerchantAccount::new(26, "com.example.pay").merchant_id("12345678");
+//! let payment = MerchantPayment::new(account, "840", "US", "Acme Coffee", "Springfield")
+//!     .amount("4.50");
+//! let qr = QRCode::from_string(payment.to_emvco());
+//! assert!(qr.try_to_qrcode().is_ok());
+//! ```
+//!
+//! [emvco]: https://www.emvco.com/emv-technologies/qrcodes/
+
+/// CRC-16/CCITT-FALSE (poly `0x1021`, init `0xFFFF`) over `data`, as required by
+/// EMVCo tag 63.
+fn crc16(data: &[u8]) -> u16 {
+    let mut crc: u16 = 0xFFFF;
+    for &byte in data {
+        crc ^= u16::from(byte) << 8;
+        for _ in 0..8 {
+            crc = if crc & 0x8000 != 0 {
+                (crc << 1) ^ 0x1021
+            } else {
+                crc << 1
+            };
+        }
+    }
+    crc
+}
+
+/// Encodes one EMVCo data object as `ID || LEN || VALUE` (two-digit length).
+fn tlv(id: &str, value: &str) -> String {
+    format!("{id}{:02}{value}", value.len())
+}
+
+/// A merchant account information object (tags 26–51): a globally-unique
+/// identifier plus an optional scheme-specific merchant id.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MerchantAccount {
+    /// Tag in the 26–51 range that identifies the payment scheme.
+    tag: u8,
+    /// Globally unique identifier (sub-tag 00), e.g. a reverse-DNS string.
+    guid: String,
+    /// Scheme-specific merchant identifier (sub-tag 01).
+    merchant_id: Option<String>,
+}
+
+impl MerchantAccount {
+    /// Creates account information under `tag` (clamped to 26–51) with the given
+    /// globally-unique identifier.
+    #[must_use]
+    pub fn new(tag: u8, guid: impl Into<String>) -> Self {
+        MerchantAccount {
+            tag: tag.clamp(26, 51),
+            guid: guid.into(),
+            merchant_id: None,
+        }
+    }
+
+    /// Sets the scheme-specific merchant id (sub-tag 01).
+    #[must_use]
+    pub fn merchant_id(mut self, id: impl Into<String>) -> Self {
+        self.merchant_id = Some(id.into());
+        self
+    }
+
+    /// Serialises to the outer `tag || len || (sub-TLVs)` object.
+    fn to_tlv(&self) -> String {
+        let mut inner = tlv("00", &self.guid);
+        if let Some(id) = &self.merchant_id {
+            inner.push_str(&tlv("01", id));
+        }
+        tlv(&format!("{:02}", self.tag), &inner)
+    }
+}
+
+/// An EMVCo merchant-presented payment that serialises to a scannable string.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MerchantPayment {
+    /// Merchant account information (tags 26–51).
+    account: MerchantAccount,
+    /// Merchant Category Code (tag 52).
+    category_code: String,
+    /// Transaction currency, ISO 4217 numeric (tag 53), e.g. `840` for USD.
+    currency: String,
+    /// Transaction amount (tag 54); when present the code is dynamic.
+    amount: Option<String>,
+    /// Country code, ISO 3166-1 alpha-2 (tag 58).
+    country_code: String,
+    /// Merchant name (tag 59).
+    merchant_name: String,
+    /// Merchant city (tag 60).
+    merchant_city: String,
+}
+
+impl MerchantPayment {
+    /// Creates a static payment with the required fields. `currency` is the
+    /// ISO 4217 numeric code and `country_code` the ISO 3166-1 alpha-2 code.
+    #[must_use]
+    pub fn new(
+        account: MerchantAccount,
+        currency: impl Into<String>,
+        country_code: impl Into<String>,
+        merchant_name: impl Into<String>,
+        merchant_city: impl Into<String>,
+    ) -> Self {
+        MerchantPayment {
+            account,
+            category_code: "0000".to_string(),
+            currency: currency.into(),
+            amount: None,
+            country_code: country_code.into(),
+            merchant_name: merchant_name.into(),
+            merchant_city: merchant_city.into(),
+        }
+    }
+
+    /// Sets the Merchant Category Code (tag 52).
+    #[must_use]
+    pub fn category_code(mut self, mcc: impl Into<String>) -> Self {
+        self.category_code = mcc.into();
+        self
+    }
+
+    /// Sets the transaction amount (tag 54), making the code dynamic.
+    #[must_use]
+    pub fn amount(mut self, amount: impl Into<String>) -> Self {
+        self.amount = Some(amount.into());
+        self
+    }
+
+    /// Serialises to the full EMVCo MPM payload, including the trailing CRC.
+    #[must_use]
+    pub fn to_emvco(&self) -> String {
+        let mut s = String::new();
+        s.push_str(&tlv("00", "01")); // payload format indicator
+                                      // point of initiation: 11 static, 12 dynamic
+        s.push_str(&tlv("01", if self.amount.is_some() { "12" } else { "11" }));
+        s.push_str(&self.account.to_tlv());
+        s.push_str(&tlv("52", &self.category_code));
+        s.push_str(&tlv("53", &self.currency));
+        if let Some(amount) = &self.amount {
+            s.push_str(&tlv("54", amount));
+        }
+        s.push_str(&tlv("58", &self.country_code));
+        s.push_str(&tlv("59", &self.merchant_name));
+        s.push_str(&tlv("60", &self.merchant_city));
+        // CRC is computed over everything including the tag+length "6304".
+        s.push_str("6304");
+        s.push_str(&format!("{:04X}", crc16(s.as_bytes())));
+        s
+    }
+}
+
+impl core::fmt::Display for MerchantPayment {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.to_emvco())
+    }
+}

--- a/src/payload/mecard.rs
+++ b/src/payload/mecard.rs
@@ -1,0 +1,138 @@
+// Copyright © 2022-2026 QR Code Library (QRC). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! MeCard contact payloads.
+//!
+//! MeCard is a compact contact format (originating with NTT DoCoMo) that many
+//! scanners support alongside vCard; it is shorter, so it fits in a smaller QR.
+//! For a richer business card use [`crate::payload::vcard`].
+//!
+//! ```
+//! use qrc::payload::mecard::MeCard;
+//! use qrc::QRCode;
+//!
+//! let card = MeCard::new("Doe,Jane").phone("+15550100").email("jane@acme.example");
+//! let qr = QRCode::from_string(card.to_mecard());
+//! assert!(qr.try_to_qrcode().is_ok());
+//! ```
+
+/// Escapes a value for a MeCard field: `\`, `;`, `:` and `,` are
+/// backslash-escaped.
+fn escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(ch, '\\' | ';' | ':' | ',') {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// A MeCard contact that serialises to a `MECARD:...;;` string.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MeCard {
+    /// Name, conventionally `Last,First` (`N:`).
+    name: String,
+    /// Phonetic reading of the name (`SOUND:`).
+    reading: Option<String>,
+    /// Telephone number (`TEL:`).
+    phone: Option<String>,
+    /// Email address (`EMAIL:`).
+    email: Option<String>,
+    /// Website URL (`URL:`).
+    url: Option<String>,
+    /// Address (`ADR:`).
+    address: Option<String>,
+    /// Birthday as `YYYYMMDD` (`BDAY:`).
+    birthday: Option<String>,
+    /// Free-form note (`NOTE:`).
+    note: Option<String>,
+}
+
+impl MeCard {
+    /// Creates a card with the given name (conventionally `Last,First`).
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        MeCard {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Sets the phonetic reading of the name.
+    #[must_use]
+    pub fn reading(mut self, reading: impl Into<String>) -> Self {
+        self.reading = Some(reading.into());
+        self
+    }
+
+    /// Sets the telephone number.
+    #[must_use]
+    pub fn phone(mut self, phone: impl Into<String>) -> Self {
+        self.phone = Some(phone.into());
+        self
+    }
+
+    /// Sets the email address.
+    #[must_use]
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+
+    /// Sets the website URL.
+    #[must_use]
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Sets the address.
+    #[must_use]
+    pub fn address(mut self, address: impl Into<String>) -> Self {
+        self.address = Some(address.into());
+        self
+    }
+
+    /// Sets the birthday (`YYYYMMDD`).
+    #[must_use]
+    pub fn birthday(mut self, birthday: impl Into<String>) -> Self {
+        self.birthday = Some(birthday.into());
+        self
+    }
+
+    /// Sets a free-form note.
+    #[must_use]
+    pub fn note(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+
+    /// Serialises the contact to its `MECARD:...;;` payload string.
+    #[must_use]
+    pub fn to_mecard(&self) -> String {
+        let mut s = format!("MECARD:N:{};", escape(&self.name));
+        for (tag, value) in [
+            ("SOUND", &self.reading),
+            ("TEL", &self.phone),
+            ("EMAIL", &self.email),
+            ("URL", &self.url),
+            ("ADR", &self.address),
+            ("BDAY", &self.birthday),
+            ("NOTE", &self.note),
+        ] {
+            if let Some(v) = value {
+                s.push_str(&format!("{tag}:{};", escape(v)));
+            }
+        }
+        s.push(';');
+        s
+    }
+}
+
+impl core::fmt::Display for MeCard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.to_mecard())
+    }
+}

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -1,0 +1,19 @@
+// Copyright © 2022-2026 QR Code Library (QRC). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Structured payload builders.
+//!
+//! These turn structured data into the exact text conventions that QR scanners
+//! recognise (contacts, etc.), so the decoded code triggers a rich action
+//! rather than showing raw text. They are plain string builders with no extra
+//! dependencies.
+
+pub mod emvco;
+pub mod mecard;
+pub mod vcard;
+pub mod wifi;
+
+pub use emvco::{MerchantAccount, MerchantPayment};
+pub use mecard::MeCard;
+pub use vcard::BusinessCard;
+pub use wifi::{WifiNetwork, WifiSecurity};

--- a/src/payload/vcard.rs
+++ b/src/payload/vcard.rs
@@ -1,0 +1,179 @@
+// Copyright © 2022-2026 QR Code Library (QRC). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Business-card (vCard) payloads.
+//!
+//! [`BusinessCard`] builds an [RFC 6350](https://www.rfc-editor.org/rfc/rfc6350)
+//! / vCard 3.0 string that QR scanners recognise as a contact, prompting "add
+//! to contacts" rather than showing raw text. Encode the result like any other
+//! string:
+//!
+//! ```
+//! use qrc::payload::vcard::BusinessCard;
+//! use qrc::QRCode;
+//!
+//! let card = BusinessCard::new("Jane Doe")
+//!     .organization("Acme, Inc.")
+//!     .title("CEO")
+//!     .phone("+1-555-0100")
+//!     .email("jane@acme.example");
+//! let qr = QRCode::from_string(card.to_vcard());
+//! assert!(qr.try_to_qrcode().is_ok());
+//! ```
+
+/// Escapes a value for inclusion in a vCard property per RFC 6350 §3.4:
+/// backslash, comma and semicolon are escaped, and newlines become `\n`.
+fn escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            ',' => out.push_str("\\,"),
+            ';' => out.push_str("\\;"),
+            '\n' => out.push_str("\\n"),
+            '\r' => {}
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// A contact / business card that serialises to a vCard 3.0 string.
+///
+/// Only [`BusinessCard::new`] (the formatted name) is required; every other
+/// field is optional and omitted from the output when unset.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BusinessCard {
+    /// Formatted display name (vCard `FN`, required).
+    full_name: String,
+    /// Given (first) name, used to build the structured `N` property.
+    first_name: Option<String>,
+    /// Family (last) name, used to build the structured `N` property.
+    last_name: Option<String>,
+    /// Organisation (`ORG`).
+    organization: Option<String>,
+    /// Job title (`TITLE`).
+    title: Option<String>,
+    /// Telephone number (`TEL;TYPE=CELL`).
+    phone: Option<String>,
+    /// Email address (`EMAIL`).
+    email: Option<String>,
+    /// Website URL (`URL`).
+    url: Option<String>,
+    /// Free-form street/city address (`ADR;TYPE=WORK`).
+    address: Option<String>,
+    /// Free-form note (`NOTE`).
+    note: Option<String>,
+}
+
+impl BusinessCard {
+    /// Creates a card with the given formatted (display) name.
+    #[must_use]
+    pub fn new(full_name: impl Into<String>) -> Self {
+        BusinessCard {
+            full_name: full_name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Sets the structured given/family name (`N` property).
+    #[must_use]
+    pub fn name(mut self, first: impl Into<String>, last: impl Into<String>) -> Self {
+        self.first_name = Some(first.into());
+        self.last_name = Some(last.into());
+        self
+    }
+
+    /// Sets the organisation.
+    #[must_use]
+    pub fn organization(mut self, org: impl Into<String>) -> Self {
+        self.organization = Some(org.into());
+        self
+    }
+
+    /// Sets the job title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Sets the telephone number.
+    #[must_use]
+    pub fn phone(mut self, phone: impl Into<String>) -> Self {
+        self.phone = Some(phone.into());
+        self
+    }
+
+    /// Sets the email address.
+    #[must_use]
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+
+    /// Sets the website URL.
+    #[must_use]
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Sets a free-form address line.
+    #[must_use]
+    pub fn address(mut self, address: impl Into<String>) -> Self {
+        self.address = Some(address.into());
+        self
+    }
+
+    /// Sets a free-form note.
+    #[must_use]
+    pub fn note(mut self, note: impl Into<String>) -> Self {
+        self.note = Some(note.into());
+        self
+    }
+
+    /// Serialises the card to a vCard 3.0 string.
+    #[must_use]
+    pub fn to_vcard(&self) -> String {
+        let mut s = String::from("BEGIN:VCARD\r\nVERSION:3.0\r\n");
+
+        // Structured name (N): Family;Given;;;
+        if self.first_name.is_some() || self.last_name.is_some() {
+            let last = self.last_name.as_deref().unwrap_or_default();
+            let first = self.first_name.as_deref().unwrap_or_default();
+            s.push_str(&format!("N:{};{};;;\r\n", escape(last), escape(first)));
+        }
+
+        s.push_str(&format!("FN:{}\r\n", escape(&self.full_name)));
+
+        for (prop, value) in [
+            ("ORG", &self.organization),
+            ("TITLE", &self.title),
+            ("URL", &self.url),
+            ("NOTE", &self.note),
+        ] {
+            if let Some(v) = value {
+                s.push_str(&format!("{prop}:{}\r\n", escape(v)));
+            }
+        }
+        if let Some(phone) = &self.phone {
+            s.push_str(&format!("TEL;TYPE=CELL:{}\r\n", escape(phone)));
+        }
+        if let Some(email) = &self.email {
+            s.push_str(&format!("EMAIL:{}\r\n", escape(email)));
+        }
+        if let Some(address) = &self.address {
+            s.push_str(&format!("ADR;TYPE=WORK:;;{};;;;\r\n", escape(address)));
+        }
+
+        s.push_str("END:VCARD");
+        s
+    }
+}
+
+impl core::fmt::Display for BusinessCard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.to_vcard())
+    }
+}

--- a/src/payload/wifi.rs
+++ b/src/payload/wifi.rs
@@ -1,0 +1,122 @@
+// Copyright © 2022-2026 QR Code Library (QRC). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Wi-Fi network join payloads.
+//!
+//! [`WifiNetwork`] builds the `WIFI:...;;` string that phone cameras recognise
+//! to offer "join network". Encode it like any other string:
+//!
+//! ```
+//! use qrc::payload::wifi::{WifiNetwork, WifiSecurity};
+//! use qrc::QRCode;
+//!
+//! let wifi = WifiNetwork::new("Cafe Guest")
+//!     .security(WifiSecurity::Wpa)
+//!     .password("latte123");
+//! let qr = QRCode::from_string(wifi.to_qr_string());
+//! assert!(qr.try_to_qrcode().is_ok());
+//! ```
+
+/// The authentication type of a Wi-Fi network.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum WifiSecurity {
+    /// WPA/WPA2/WPA3 personal (the common case).
+    #[default]
+    Wpa,
+    /// Legacy WEP.
+    Wep,
+    /// Open network (no password).
+    None,
+}
+
+impl WifiSecurity {
+    /// The `T:` token value used in the payload.
+    fn token(self) -> &'static str {
+        match self {
+            WifiSecurity::Wpa => "WPA",
+            WifiSecurity::Wep => "WEP",
+            WifiSecurity::None => "nopass",
+        }
+    }
+}
+
+/// Escapes a value for a Wi-Fi payload: `\`, `;`, `,`, `:` and `"` are
+/// backslash-escaped per the de-facto MeCard-style convention.
+fn escape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(ch, '\\' | ';' | ',' | ':' | '"') {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// A Wi-Fi network that serialises to a `WIFI:...;;` join string.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WifiNetwork {
+    /// Network name (SSID).
+    ssid: String,
+    /// Pre-shared key / password (omitted for open networks).
+    password: Option<String>,
+    /// Authentication type.
+    security: WifiSecurity,
+    /// Whether the SSID is hidden (not broadcast).
+    hidden: bool,
+}
+
+impl WifiNetwork {
+    /// Creates a network with the given SSID (WPA by default).
+    #[must_use]
+    pub fn new(ssid: impl Into<String>) -> Self {
+        WifiNetwork {
+            ssid: ssid.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Sets the authentication type.
+    #[must_use]
+    pub fn security(mut self, security: WifiSecurity) -> Self {
+        self.security = security;
+        self
+    }
+
+    /// Sets the password / pre-shared key.
+    #[must_use]
+    pub fn password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    /// Marks the SSID as hidden.
+    #[must_use]
+    pub fn hidden(mut self, hidden: bool) -> Self {
+        self.hidden = hidden;
+        self
+    }
+
+    /// Serialises the network to its `WIFI:...;;` payload string.
+    #[must_use]
+    pub fn to_qr_string(&self) -> String {
+        let mut s = format!("WIFI:T:{};S:{};", self.security.token(), escape(&self.ssid));
+        // Open networks carry no key.
+        if self.security != WifiSecurity::None {
+            if let Some(password) = &self.password {
+                s.push_str(&format!("P:{};", escape(password)));
+            }
+        }
+        if self.hidden {
+            s.push_str("H:true;");
+        }
+        s.push(';');
+        s
+    }
+}
+
+impl core::fmt::Display for WifiNetwork {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.to_qr_string())
+    }
+}

--- a/tests/payloads.rs
+++ b/tests/payloads.rs
@@ -1,0 +1,126 @@
+//! Structured payload builders: Wi-Fi, MeCard and EMVCo merchant payments.
+
+use qrc::payload::emvco::{MerchantAccount, MerchantPayment};
+use qrc::payload::mecard::MeCard;
+use qrc::payload::wifi::{WifiNetwork, WifiSecurity};
+use qrc::QRCode;
+
+/// Asserts that `payload` encodes to a valid QR code (correct version selected,
+/// no panic) — i.e. the builder output is within QR capacity and encodable.
+fn encodes(payload: &str) {
+    assert!(QRCode::from_string(payload.to_string())
+        .try_to_qrcode()
+        .is_ok());
+}
+
+// --- Wi-Fi -----------------------------------------------------------------
+
+#[test]
+fn wifi_wpa_with_password_and_hidden() {
+    let wifi = WifiNetwork::new("Cafe; Guest")
+        .security(WifiSecurity::Wpa)
+        .password("p:a,s\"s\\word")
+        .hidden(true);
+    let s = wifi.to_qr_string();
+    assert_eq!(
+        s,
+        "WIFI:T:WPA;S:Cafe\\; Guest;P:p\\:a\\,s\\\"s\\\\word;H:true;;"
+    );
+    assert_eq!(wifi.to_string(), s);
+    encodes(&s);
+}
+
+#[test]
+fn wifi_open_network_omits_password() {
+    // An open network drops the key even if one was set.
+    let s = WifiNetwork::new("Free WiFi")
+        .security(WifiSecurity::None)
+        .password("ignored")
+        .to_qr_string();
+    assert_eq!(s, "WIFI:T:nopass;S:Free WiFi;;");
+}
+
+#[test]
+fn wifi_wep_without_password_or_hidden() {
+    let s = WifiNetwork::new("Old")
+        .security(WifiSecurity::Wep)
+        .to_qr_string();
+    assert_eq!(s, "WIFI:T:WEP;S:Old;;");
+    assert_eq!(WifiSecurity::default(), WifiSecurity::Wpa);
+    assert_eq!(WifiNetwork::default(), WifiNetwork::new(""));
+}
+
+// --- MeCard ----------------------------------------------------------------
+
+#[test]
+fn mecard_full_and_minimal() {
+    let card = MeCard::new("Doe,Jane")
+        .reading("doe,jane")
+        .phone("+15550100")
+        .email("jane@acme.example")
+        .url("https://acme.example")
+        .address("1 Market St")
+        .birthday("19900101")
+        .note("hi; there");
+    let s = card.to_mecard();
+    assert!(s.starts_with("MECARD:N:Doe\\,Jane;"));
+    assert!(s.contains("TEL:+15550100;"));
+    assert!(s.contains("SOUND:doe\\,jane;"));
+    assert!(s.contains("NOTE:hi\\; there;"));
+    assert!(s.ends_with(";;"));
+    assert_eq!(card.to_string(), s);
+    encodes(&s);
+
+    let minimal = MeCard::new("Solo").to_mecard();
+    assert_eq!(minimal, "MECARD:N:Solo;;");
+    assert_eq!(MeCard::default(), MeCard::new(""));
+}
+
+// --- EMVCo -----------------------------------------------------------------
+
+#[test]
+fn emvco_dynamic_payment_round_trips_and_has_valid_crc() {
+    let account = MerchantAccount::new(26, "com.example.pay").merchant_id("12345678");
+    let payment = MerchantPayment::new(account, "840", "US", "Acme Coffee", "Springfield")
+        .category_code("5814")
+        .amount("4.50");
+    let s = payment.to_emvco();
+
+    assert!(s.starts_with("000201")); // payload format indicator
+    assert!(s.contains("010212")); // dynamic point-of-initiation
+    assert!(s.contains("5303840")); // currency 840
+    assert!(s.contains("54044.50")); // amount
+    assert!(s.contains("5802US")); // country
+    assert_eq!(payment.to_string(), s);
+    encodes(&s);
+
+    // The trailing 4 hex chars are a correct CRC over the rest + "6304".
+    let (body, crc) = s.split_at(s.len() - 4);
+    let mut c: u16 = 0xFFFF;
+    for &b in body.as_bytes() {
+        c ^= u16::from(b) << 8;
+        for _ in 0..8 {
+            c = if c & 0x8000 != 0 {
+                (c << 1) ^ 0x1021
+            } else {
+                c << 1
+            };
+        }
+    }
+    assert_eq!(crc, format!("{c:04X}"));
+}
+
+#[test]
+fn emvco_static_payment_and_tag_clamping() {
+    // No amount -> static (point of initiation 11), no tag 54.
+    let account = MerchantAccount::new(10, "com.example"); // tag clamped up to 26
+    let s = MerchantPayment::new(account, "978", "FR", "Boulangerie", "Paris").to_emvco();
+    assert!(s.contains("010211")); // static
+    assert!(!s.contains("5404"));
+    assert!(s.contains("26150011com.example")); // tag 26, len 15, inner 00||11||com.example
+
+    // Tag above range clamps down to 51.
+    let high = MerchantAccount::new(99, "g");
+    let s = MerchantPayment::new(high, "840", "US", "M", "C").to_emvco();
+    assert!(s.contains("51050001g")); // clamped tag 51, inner = 00||01||g
+}


### PR DESCRIPTION
First of the feature ports from the closed **#62** (layered branch) onto the current `feat/v0.0.6` architecture — see #62 for the plan.

## Adds
Dependency-free string builders that emit the exact text conventions QR scanners recognise:
- `payload::vcard::BusinessCard` — RFC 6350 contact card
- `payload::wifi::WifiNetwork` — `WIFI:` join string
- `payload::mecard::MeCard` — compact contact
- `payload::emvco::MerchantPayment` — EMVCo MPM + CRC-16/CCITT-FALSE

Exposed as an unconditional `pub mod payload` (zero deps, no feature gate). Four runnable examples (`vcard`/`wifi`/`mecard`/`emvco`).

## Notes
- `tests/payloads.rs` adapted to the flat `QRCode` API: the round-trip helper proves encodability via `try_to_qrcode()` rather than decoding a PNG — avoids adding `rqrr`/`image` dev-deps, which would re-pull the full `image` codec stack removed in #65.
- Keeps all builder-output + EMVCo CRC assertions.

## Verification
- `cargo build` / `--all-features` ✅
- tests: 6 unit + 4 doctests ✅
- `cargo clippy --all-targets --all-features` (0) ✅ · `cargo fmt --check` ✅

Next ports (separate PRs): branded business-card example, AI art-QR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)