### PR TITLE
feat(art): offline art-QR primitives (control image + blend)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,3 +167,11 @@ path = "examples/mecard.rs"
 [[example]]
 name = "emvco"
 path = "examples/emvco.rs"
+
+[[example]]
+name = "control_image"
+path = "examples/control_image.rs"
+
+[[example]]
+name = "art_qr"
+path = "examples/art_qr.rs"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - [Library Usage](#library-usage) — formats, styling, watermarks
 - [Structured Payloads](#structured-payloads) — vCard, Wi-Fi, MeCard, EMVCo
 - [Macros](#macros) — 11 convenience macros
-- [Examples](#examples) — 17 focused examples
+- [Examples](#examples) — 19 focused examples
 - [Development](#development) — build, test, lint
 - [Security](#security) — safety guarantees
 - [Documentation](#documentation)
@@ -323,6 +323,8 @@ cargo run --example vcard
 | `wifi` | Wi-Fi join code |
 | `mecard` | Compact MeCard contact |
 | `emvco` | EMVCo merchant payment |
+| `control_image` | Export a ControlNet control image (for SD QR art) |
+| `art_qr` | Offline image-blended "art QR" — no model needed |
 
 ---
 

--- a/examples/art_qr.rs
+++ b/examples/art_qr.rs
@@ -1,0 +1,47 @@
+//! Offline "art QR": blend an image through the code — no AI model needed.
+//!
+//! A background (a procedural gradient here, or a file you pass in) shows
+//! through the data modules while finder patterns, the quiet zone, and a centre
+//! dot per module keep it scannable. High error correction keeps the blended
+//! regions recoverable.
+//!
+//!   cargo run --example art_qr                 # procedural gradient background
+//!   cargo run --example art_qr -- photo.png    # your own background
+
+use image::{ImageBuffer, Rgba, RgbaImage};
+use qrc::{BlendOptions, EcLevel, QRCode};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let qr = QRCode::from_string("https://docs.rs/qrc".to_string()).with_ec_level(EcLevel::H);
+
+    // A real background if supplied, else a diagonal blue→magenta gradient.
+    let background: RgbaImage = match std::env::args().nth(1) {
+        Some(path) => image::open(path)?.to_rgba8(),
+        None => gradient(512),
+    };
+
+    // strength: higher = scans better; lower = more image shows through.
+    let opts = BlendOptions {
+        strength: 0.7,
+        ..BlendOptions::default()
+    };
+    let art = qr.blend_image(&background, &opts);
+    art.save("art_qr.png")?;
+
+    println!(
+        "Wrote art_qr.png ({}x{}) — a scannable, image-blended QR code.",
+        art.width(),
+        art.height()
+    );
+    Ok(())
+}
+
+/// A simple diagonal gradient used when no background image is supplied.
+fn gradient(size: u32) -> RgbaImage {
+    ImageBuffer::from_fn(size, size, |x, y| {
+        let t = (x + y) as f32 / (2.0 * size as f32); // 0.0 → 1.0 across the diagonal
+        let r = (t * 220.0) as u8;
+        let b = (220.0 - t * 80.0) as u8;
+        Rgba([r, 40, b, 255])
+    })
+}

--- a/examples/control_image.rs
+++ b/examples/control_image.rs
@@ -1,0 +1,24 @@
+//! Export a ControlNet-ready control image.
+//!
+//! Feed `control.png` to Stable Diffusion + a QR ControlNet (e.g. *QR Code
+//! Monster*) as the control input to generate AI "art QR" codes. High error
+//! correction gives the model the most room to hide art behind.
+//!
+//!   cargo run --example control_image
+
+use qrc::{EcLevel, QRCode};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let qr = QRCode::from_string("https://docs.rs/qrc".to_string()).with_ec_level(EcLevel::H);
+
+    // Square, centred, high-contrast, with a generous quiet zone.
+    let control = qr.to_control_image(768);
+    control.save("control.png")?;
+
+    println!(
+        "Wrote control.png ({}x{}) — use it as the ControlNet control image.",
+        control.width(),
+        control.height()
+    );
+    Ok(())
+}

--- a/src/art.rs
+++ b/src/art.rs
@@ -1,0 +1,151 @@
+// Copyright © 2022-2026 QR Code Library (QRC). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Offline "art QR" primitives.
+//!
+//! Two model-free building blocks for artistic QR codes:
+//!
+//! * [`QRCode::to_control_image`](crate::QRCode::to_control_image) exports a
+//!   clean, high-contrast, square control image — the input a Stable Diffusion
+//!   QR ControlNet (e.g. *QR Code Monster*) expects.
+//! * [`QRCode::blend_image`](crate::QRCode::blend_image) weaves a supplied
+//!   background image through the code's data modules while keeping finder
+//!   patterns, the quiet zone, and a centre dot in every module solid, so the
+//!   result stays scannable without any model at all.
+//!
+//! Pair both with the highest error-correction level
+//! ([`with_ec_level`](crate::QRCode::with_ec_level) + `EcLevel::H`) so the
+//! blended regions stay recoverable.
+
+use image::{imageops, ImageBuffer, Rgba, RgbaImage};
+use qrcode::{Color, QrCode};
+
+/// Quiet-zone width, in modules (the QR specification mandates 4).
+const QUIET: u32 = 4;
+
+const BLACK: [u8; 4] = [0, 0, 0, 255];
+const WHITE: [u8; 4] = [255, 255, 255, 255];
+
+/// Tuning for [`QRCode::blend_image`](crate::QRCode::blend_image).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BlendOptions {
+    /// Pixels per module in the output image.
+    pub module_size: u32,
+    /// How strongly each module tints the background outside its centre dot,
+    /// in `0.0..=1.0` (0 = image only, 1 = solid module). Higher scans more
+    /// reliably; lower shows more of the image.
+    pub strength: f32,
+    /// Diameter of the always-solid centre dot relative to the module, in
+    /// `0.0..=1.0`. The dots carry most of the scannable signal.
+    pub dot_ratio: f32,
+}
+
+impl Default for BlendOptions {
+    fn default() -> Self {
+        BlendOptions {
+            module_size: 12,
+            strength: 0.75,
+            dot_ratio: 0.66,
+        }
+    }
+}
+
+/// Renders `code` to a square, centred, high-contrast control image with a
+/// generous quiet zone. The modules are integer-scaled to fill `size` as
+/// closely as possible; if they cannot fit, the canvas grows to the next whole
+/// module rather than distorting them.
+pub(crate) fn control_image(code: &QrCode, size: u32) -> RgbaImage {
+    let n = code.width() as u32;
+    let total = n + 2 * QUIET;
+    let module_px = (size / total).max(1);
+    let qr_dim = module_px * total;
+    let dim = size.max(qr_dim);
+    let offset = (dim - qr_dim) / 2;
+
+    let mut img: RgbaImage = ImageBuffer::from_pixel(dim, dim, Rgba(WHITE));
+    for y in 0..n {
+        for x in 0..n {
+            if code[(x as usize, y as usize)] != Color::Dark {
+                continue;
+            }
+            let px0 = offset + (x + QUIET) * module_px;
+            let py0 = offset + (y + QUIET) * module_px;
+            for dy in 0..module_px {
+                for dx in 0..module_px {
+                    img.put_pixel(px0 + dx, py0 + dy, Rgba(BLACK));
+                }
+            }
+        }
+    }
+    img
+}
+
+/// Weaves `background` into `code`, returning a branded, scannable image. The
+/// background is resized to the output dimensions; an empty background is
+/// treated as a blank light canvas.
+pub(crate) fn blend(code: &QrCode, background: &RgbaImage, opts: &BlendOptions) -> RgbaImage {
+    let n = code.width() as u32;
+    let total = n + 2 * QUIET;
+    let m = opts.module_size.max(1);
+    let dim = total * m;
+
+    let bg: RgbaImage = if background.width() == 0 || background.height() == 0 {
+        ImageBuffer::from_pixel(dim, dim, Rgba(WHITE))
+    } else {
+        imageops::resize(background, dim, dim, imageops::FilterType::Lanczos3)
+    };
+
+    let mut out: RgbaImage = ImageBuffer::new(dim, dim);
+    let center = (m as f32 - 1.0) / 2.0;
+    let dot_r = m as f32 * opts.dot_ratio.clamp(0.0, 1.0) / 2.0;
+
+    for my in 0..total {
+        for mx in 0..total {
+            let is_quiet = mx < QUIET || my < QUIET || mx >= QUIET + n || my >= QUIET + n;
+            let (dx_mod, dy_mod) = (mx.wrapping_sub(QUIET), my.wrapping_sub(QUIET));
+            let dark_module = !is_quiet && code[(dx_mod as usize, dy_mod as usize)] == Color::Dark;
+            let finder = !is_quiet && in_finder(dx_mod as usize, dy_mod as usize, n as usize);
+            let tint = if dark_module { BLACK } else { WHITE };
+
+            for dy in 0..m {
+                for dx in 0..m {
+                    let (px, py) = (mx * m + dx, my * m + dy);
+                    let pixel = if is_quiet || finder {
+                        Rgba(tint)
+                    } else {
+                        let ddx = dx as f32 - center;
+                        let ddy = dy as f32 - center;
+                        if (ddx * ddx + ddy * ddy).sqrt() <= dot_r {
+                            Rgba(tint) // solid centre dot
+                        } else {
+                            mix(*bg.get_pixel(px, py), tint, opts.strength)
+                        }
+                    };
+                    out.put_pixel(px, py, pixel);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Whether data coordinate `(x, y)` lies in one of the three 7×7 finder
+/// patterns, which are always rendered solidly so detection stays robust.
+fn in_finder(x: usize, y: usize, size: usize) -> bool {
+    const F: usize = 7;
+    let (left, right) = (x < F, x >= size - F);
+    let (top, bottom) = (y < F, y >= size - F);
+    (top && (left || right)) || (bottom && left)
+}
+
+/// Linearly blends `bg` toward `tint` by `strength`.
+fn mix(bg: Rgba<u8>, tint: [u8; 4], strength: f32) -> Rgba<u8> {
+    let s = strength.clamp(0.0, 1.0);
+    let ch = |b: u8, t: u8| ((1.0 - s) * f32::from(b) + s * f32::from(t)) as u8;
+    Rgba([
+        ch(bg[0], tint[0]),
+        ch(bg[1], tint[1]),
+        ch(bg[2], tint[2]),
+        255,
+    ])
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,10 @@ pub mod macros;
 /// data into the text conventions QR scanners recognise.
 pub mod payload;
 
+/// Offline "art QR" primitives: ControlNet control images and image blending.
+mod art;
+pub use art::BlendOptions;
+
 #[cfg(feature = "wasm")]
 /// WASM bindings for the QRC library.
 pub mod wasm;
@@ -738,6 +742,51 @@ impl QRCode {
         }
 
         combined_image
+    }
+
+    /// Exports a square, high-contrast control image for a Stable Diffusion QR
+    /// ControlNet (e.g. *QR Code Monster*).
+    ///
+    /// The modules are integer-scaled and centred on a `size`×`size` canvas with
+    /// a 4-module quiet zone; if they cannot fit exactly, the canvas grows to the
+    /// next whole module rather than distorting them. Pair with
+    /// [`with_ec_level`](Self::with_ec_level) + `EcLevel::H` so the model has the
+    /// most redundancy to hide art behind.
+    ///
+    /// ```
+    /// use qrc::{QRCode, EcLevel};
+    ///
+    /// let img = QRCode::from_string("https://example.com".to_string())
+    ///     .with_ec_level(EcLevel::H)
+    ///     .to_control_image(768);
+    /// assert!(img.width() >= 768 && img.width() == img.height());
+    /// ```
+    #[must_use]
+    pub fn to_control_image(&self, size: u32) -> RgbaImage {
+        art::control_image(&self.to_qrcode(), size)
+    }
+
+    /// Weaves a `background` image through the code's data modules, returning a
+    /// branded, scannable "art QR" with no model required.
+    ///
+    /// Finder patterns, the quiet zone, and a centre dot in every module stay
+    /// solid; everything else blends the background toward the module colour by
+    /// [`BlendOptions::strength`]. Use [`with_ec_level`](Self::with_ec_level) +
+    /// `EcLevel::H` so the blended regions stay recoverable.
+    ///
+    /// ```
+    /// use qrc::{QRCode, EcLevel, BlendOptions};
+    /// use image::{ImageBuffer, Rgba};
+    ///
+    /// let bg = ImageBuffer::from_pixel(64, 64, Rgba([0, 120, 220, 255]));
+    /// let art = QRCode::from_string("https://example.com".to_string())
+    ///     .with_ec_level(EcLevel::H)
+    ///     .blend_image(&bg, &BlendOptions::default());
+    /// assert_eq!(art.width(), art.height());
+    /// ```
+    #[must_use]
+    pub fn blend_image(&self, background: &RgbaImage, opts: &BlendOptions) -> RgbaImage {
+        art::blend(&self.to_qrcode(), background, opts)
     }
 
     /// Sets the encoding format of the QR code.

--- a/tests/art_qr.rs
+++ b/tests/art_qr.rs
@@ -1,0 +1,44 @@
+//! Offline art-QR primitives: ControlNet control image + image blend.
+
+use image::{ImageBuffer, Rgba, RgbaImage};
+use qrc::{BlendOptions, EcLevel, QRCode};
+
+#[test]
+fn control_image_is_square_and_at_least_requested_size() {
+    let img = QRCode::from_string("https://example.com".to_string())
+        .with_ec_level(EcLevel::H)
+        .to_control_image(768);
+    assert_eq!(img.width(), img.height());
+    assert!(img.width() >= 768);
+}
+
+#[test]
+fn control_image_grows_to_whole_modules_when_too_small() {
+    // A tiny requested size can't fit the modules → the canvas grows to whole
+    // modules rather than distorting them.
+    let img = QRCode::from_string("hello".to_string()).to_control_image(8);
+    assert_eq!(img.width(), img.height());
+    assert!(img.width() >= 8);
+}
+
+#[test]
+fn blend_dimensions_match_total_modules_times_module_size() {
+    let qr = QRCode::from_string("https://example.com".to_string()).with_ec_level(EcLevel::H);
+    let n = qr.try_to_qrcode().unwrap().width() as u32;
+    let opts = BlendOptions {
+        module_size: 10,
+        ..BlendOptions::default()
+    };
+    let bg = ImageBuffer::from_pixel(50, 50, Rgba([10, 20, 30, 255]));
+    let art = qr.blend_image(&bg, &opts);
+    let expected = (n + 8) * 10; // n data modules + 2×4 quiet-zone modules
+    assert_eq!(art.dimensions(), (expected, expected));
+}
+
+#[test]
+fn blend_accepts_empty_background() {
+    // An empty background is treated as a blank light canvas (no panic).
+    let empty: RgbaImage = ImageBuffer::new(0, 0);
+    let art = QRCode::from_string("x".to_string()).blend_image(&empty, &BlendOptions::default());
+    assert!(art.width() > 0);
+}


### PR DESCRIPTION
Third feature port from the closed **#62** onto the current `feat/v0.0.6` architecture (after payloads #66, branded card #68).

## Adds
A focused `art` module with two **model-free** building blocks, exposed as `QRCode` methods:

- **`to_control_image(size) -> RgbaImage`** — square, centred, high-contrast control image with a 4-module quiet zone: the input a Stable Diffusion QR ControlNet (*QR Code Monster*, etc.) expects.
- **`blend_image(background, &BlendOptions) -> RgbaImage`** — weaves an image through the data modules while keeping finder patterns, the quiet zone, and a centre dot per module solid, so the result stays scannable with **no model**.

Plus `BlendOptions` (module size / strength / dot ratio), two examples (`control_image`, `art_qr`), and a 4-case test.

## Verification
- Both outputs **decode via zxing** (`PARSES (QR_CODE) -> https://docs.rs/qrc`) ✅
- `cargo test --all-features` (incl. 2 new doctests + 4 unit tests) ✅
- `cargo clippy --all-targets --all-features` (0) ✅ · `cargo fmt --check` ✅

## Scope
Re-expressed the layered branch's `render::{control,art}` algorithms against the flat `to_qrcode()` + a manual quiet zone (the flat raster path omits one — see #68).

**Deliberately out of scope** (heavier follow-ups): the cloud Replicate `api` feature (network + API token) and the fully-local **candle** demo (multi-GB model weights). This PR lands the self-contained, dependency-free core that most users want.

This completes the #62 feature ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)