### PR TITLE
fix: centre overlay_image (#41) + bump checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -51,7 +51,7 @@ jobs:
     name: MSRV (1.75.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust 1.75.0
         uses: dtolnay/rust-toolchain@1.75.0
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -88,14 +88,14 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: EmbarkStudios/cargo-deny-action@v2
 
   audit:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -176,7 +176,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,37 +708,60 @@ impl QRCode {
         data.into_iter().map(Self::from_string).collect()
     }
 
-    /// Overlays an image on top of the QR code.
+    /// Overlays an image at the **centre** of the QR code (e.g. a logo).
+    ///
+    /// The code is rendered at a usable scale with the mandatory 4-module quiet
+    /// zone, and the overlay is centred (not pasted at the top-left corner, which
+    /// previously covered a finder pattern). Fully-transparent overlay pixels are
+    /// skipped. Keep the overlay small (≈ the central fifth) and pair it with a
+    /// high error-correction level so the result stays scannable.
     ///
     /// # Parameters
     ///
-    /// * `overlay`: A reference to the `RgbaImage` to overlay on the QR code.
+    /// * `overlay`: A reference to the `RgbaImage` to centre on the QR code.
     ///
     /// # Returns
     ///
-    /// A combined `RgbaImage` with the overlay applied.
+    /// A combined `RgbaImage` with the overlay centred on the code.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn overlay_image(&self, overlay: &RgbaImage) -> RgbaImage {
+        const MODULE_PX: u32 = 10;
+        const QUIET: u32 = 4;
+
         let qrcode = self.to_qrcode();
-        let qr_dim = qrcode.width() as u32;
+        let n = qrcode.width() as u32;
+        let dim = (n + 2 * QUIET) * MODULE_PX;
         let mut combined_image: RgbaImage =
-            ImageBuffer::from_pixel(qr_dim, qr_dim, Rgba([255, 255, 255, 255]));
+            ImageBuffer::from_pixel(dim, dim, Rgba([255, 255, 255, 255]));
 
-        for x in 0..qrcode.width() {
-            for y in 0..qrcode.width() {
-                let pixel = qrcode[(x, y)];
-                let cx = x as u32;
-                let cy = y as u32;
-
-                if pixel == Color::Dark {
-                    combined_image.put_pixel(cx, cy, Rgba([0, 0, 0, 255]));
+        for y in 0..qrcode.width() {
+            for x in 0..qrcode.width() {
+                if qrcode[(x, y)] == Color::Dark {
+                    let px0 = (x as u32 + QUIET) * MODULE_PX;
+                    let py0 = (y as u32 + QUIET) * MODULE_PX;
+                    for dy in 0..MODULE_PX {
+                        for dx in 0..MODULE_PX {
+                            combined_image.put_pixel(px0 + dx, py0 + dy, Rgba([0, 0, 0, 255]));
+                        }
+                    }
                 }
             }
         }
 
+        // Centre the overlay, skipping fully-transparent pixels and clamping to
+        // the canvas so an oversized logo can't panic.
+        let (ow, oh) = overlay.dimensions();
+        let ox = dim.saturating_sub(ow) / 2;
+        let oy = dim.saturating_sub(oh) / 2;
         for (x, y, pixel) in overlay.enumerate_pixels() {
-            combined_image.put_pixel(x, y, *pixel);
+            if pixel[3] == 0 {
+                continue;
+            }
+            let (px, py) = (ox + x, oy + y);
+            if px < dim && py < dim {
+                combined_image.put_pixel(px, py, *pixel);
+            }
         }
 
         combined_image


### PR DESCRIPTION
Fixes #41 (overlay logo centred, scaled, quiet-zone — now scannable) and applies Dependabot's checkout v7 bump. codecov/cache/fetch-metadata aren't used by these workflows. Verified: tests + clippy + fmt clean; overlay output decodes via zxing.