### PR TITLE
refactor!: fallible byte encoders → literal 100% coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     qr.to_png(512).save("qrcode.png")?;
 
     // `to_jpg` / `to_gif` return ALREADY-ENCODED bytes (`Vec<u8>`) → write them.
-    std::fs::write("qrcode.jpg", qr.to_jpg(512))?;
-    std::fs::write("qrcode.gif", qr.to_gif(512))?;
+    std::fs::write("qrcode.jpg", qr.to_jpg(512)?)?;
+    std::fs::write("qrcode.gif", qr.to_gif(512)?)?;
 
     // `to_svg` returns a `String`.
     std::fs::write("qrcode.svg", qr.to_svg(512))?;

--- a/examples/formats.rs
+++ b/examples/formats.rs
@@ -37,7 +37,7 @@ fn main() {
 
         // ── JPG output ──────────────────────────────────────────────────
         support::task_with_output("Export as JPG (compressed, print-ready)", || {
-            let jpg_bytes = qr.to_jpg(size);
+            let jpg_bytes = qr.to_jpg(size).unwrap();
             let path = dir.join("qrcode.jpg");
             fs::write(&path, &jpg_bytes).unwrap();
             vec![
@@ -49,7 +49,7 @@ fn main() {
 
         // ── GIF output ─────────────────────────────────────────────────
         support::task_with_output("Export as GIF (small palette, universal)", || {
-            let gif_bytes = qr.to_gif(size);
+            let gif_bytes = qr.to_gif(size).unwrap();
             let path = dir.join("qrcode.gif");
             fs::write(&path, &gif_bytes).unwrap();
             vec![

--- a/examples/macros.rs
+++ b/examples/macros.rs
@@ -41,9 +41,9 @@ fn main() {
 
     // ── qr_code_to! ───────────────────────────────────────────────────
     support::task_with_output("qr_code_to! — Create and convert in one step", || {
-        let png = qr_code_to!("Hello QRC".into(), "png", 128);
-        let jpg = qr_code_to!("Hello QRC".into(), "jpg", 128);
-        let gif = qr_code_to!("Hello QRC".into(), "gif", 128);
+        let png = qr_code_to!("Hello QRC".into(), "png", 128).unwrap();
+        let jpg = qr_code_to!("Hello QRC".into(), "jpg", 128).unwrap();
+        let gif = qr_code_to!("Hello QRC".into(), "gif", 128).unwrap();
         vec![
             format!("PNG: {} bytes", png.len()),
             format!("JPG: {} bytes", jpg.len()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,56 +335,59 @@ impl QRCode {
         self.render_image(width)
     }
 
-    /// Returns the PNG-encoded bytes of the QR code.
-    ///
-    /// # Panics
-    ///
-    /// Panics if PNG encoding fails (should not happen in practice).
-    #[must_use]
-    pub fn to_png_bytes(&self, width: u32) -> Vec<u8> {
+    /// Renders the QR code and encodes it to `format`, returning the bytes.
+    fn encode_bytes(&self, width: u32, format: ImageFormat) -> Result<Vec<u8>, image::ImageError> {
         let img = self.render_image(width);
         let mut buf = Cursor::new(Vec::new());
-        DynamicImage::ImageRgba8(img)
-            .write_to(&mut buf, ImageFormat::Png)
-            .expect("PNG encoding failed");
-        buf.into_inner()
+        DynamicImage::ImageRgba8(img).write_to(&mut buf, format)?;
+        Ok(buf.into_inner())
     }
 
-    /// Returns actual JPEG-encoded bytes (quality 85) of the QR code.
-    #[must_use]
-    pub fn to_jpg(&self, width: u32) -> Vec<u8> {
+    /// Returns the PNG-encoded bytes of the QR code.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`image::ImageError`] if encoding fails — for example, a
+    /// `width` of `0`, which is not a valid PNG size.
+    pub fn to_png_bytes(&self, width: u32) -> Result<Vec<u8>, image::ImageError> {
+        self.encode_bytes(width, ImageFormat::Png)
+    }
+
+    /// Returns GIF-encoded bytes of the QR code.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`image::ImageError`] if GIF encoding fails.
+    pub fn to_gif(&self, width: u32) -> Result<Vec<u8>, image::ImageError> {
+        self.encode_bytes(width, ImageFormat::Gif)
+    }
+
+    /// Returns JPEG-encoded bytes (quality 85) of the QR code.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`image::ImageError`] if encoding fails — for example, a
+    /// `width` of `0`, which is not a valid JPEG size.
+    pub fn to_jpg(&self, width: u32) -> Result<Vec<u8>, image::ImageError> {
         self.to_jpg_with_quality(width, 85)
     }
 
     /// Returns JPEG-encoded bytes at a custom quality (1-100).
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if JPEG encoding fails (should not happen in practice).
-    #[must_use]
-    pub fn to_jpg_with_quality(&self, width: u32, quality: u8) -> Vec<u8> {
+    /// Returns an [`image::ImageError`] if encoding fails — for example, a
+    /// `width` of `0`, which is not a valid JPEG size.
+    pub fn to_jpg_with_quality(
+        &self,
+        width: u32,
+        quality: u8,
+    ) -> Result<Vec<u8>, image::ImageError> {
         let img = self.render_image(width);
         let rgb = DynamicImage::ImageRgba8(img).to_rgb8();
         let mut buf = Cursor::new(Vec::new());
-        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality)
-            .encode_image(&rgb)
-            .expect("JPEG encoding failed");
-        buf.into_inner()
-    }
-
-    /// Returns actual GIF-encoded bytes of the QR code.
-    ///
-    /// # Panics
-    ///
-    /// Panics if GIF encoding fails (should not happen in practice).
-    #[must_use]
-    pub fn to_gif(&self, width: u32) -> Vec<u8> {
-        let img = self.render_image(width);
-        let mut buf = Cursor::new(Vec::new());
-        DynamicImage::ImageRgba8(img)
-            .write_to(&mut buf, ImageFormat::Gif)
-            .expect("GIF encoding failed");
-        buf.into_inner()
+        image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality).encode_image(&rgb)?;
+        Ok(buf.into_inner())
     }
 
     /// Returns the raw RGBA image buffer for the QR code.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -65,7 +65,8 @@ macro_rules! qr_code_with_ec {
 #[macro_export]
 /// Macro to create a QR code in a specified format with a given width.
 ///
-/// All arms return `Vec<u8>` containing the encoded image bytes.
+/// All arms return `Result<Vec<u8>, image::ImageError>` containing the encoded
+/// image bytes (or an encoding error, e.g. a zero width).
 ///
 /// # Parameters
 /// * `$data` - The data to be encoded in the QR code.
@@ -75,7 +76,7 @@ macro_rules! qr_code_with_ec {
 /// # Example
 /// ```
 /// use qrc::{QRCode, qr_code_to};
-/// let bytes = qr_code_to!("Hello, world!".into(), "png", 256);
+/// let bytes = qr_code_to!("Hello, world!".into(), "png", 256).unwrap();
 /// assert!(!bytes.is_empty());
 /// ```
 macro_rules! qr_code_to {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -62,12 +62,12 @@ impl WasmQRCode {
     /// Returns PNG-encoded bytes.
     #[wasm_bindgen(js_name = "toPngBytes")]
     pub fn to_png_bytes(&self, width: u32) -> Vec<u8> {
-        self.inner.to_png_bytes(width)
+        self.inner.to_png_bytes(width).unwrap_or_default()
     }
 
     /// Returns JPEG-encoded bytes (quality 85).
     #[wasm_bindgen(js_name = "toJpg")]
     pub fn to_jpg(&self, width: u32) -> Vec<u8> {
-        self.inner.to_jpg(width)
+        self.inner.to_jpg(width).unwrap_or_default()
     }
 }

--- a/tests/coverage.rs
+++ b/tests/coverage.rs
@@ -44,11 +44,16 @@ fn every_output_format() {
     let qr = QRCode::from_string(URL.to_string());
     assert_eq!(qr.to_png(64).dimensions(), (64, 64));
     assert_eq!(qr.to_image(64).dimensions(), (64, 64));
-    assert!(!qr.to_png_bytes(64).is_empty());
-    assert!(!qr.to_jpg(64).is_empty());
-    assert!(!qr.to_jpg_with_quality(64, 50).is_empty());
-    assert!(!qr.to_gif(64).is_empty());
+    assert!(!qr.to_png_bytes(64).unwrap().is_empty());
+    assert!(!qr.to_jpg(64).unwrap().is_empty());
+    assert!(!qr.to_jpg_with_quality(64, 50).unwrap().is_empty());
+    assert!(!qr.to_gif(64).unwrap().is_empty());
     assert!(qr.to_svg(64).contains("<svg"));
+
+    // Encoding errors propagate: width 0 is not a valid PNG/JPEG size.
+    assert!(qr.to_png_bytes(0).is_err());
+    assert!(qr.to_jpg(0).is_err());
+    assert!(qr.to_jpg_with_quality(0, 50).is_err());
 }
 
 #[test]
@@ -95,6 +100,12 @@ fn colorize_and_resize() {
     let qr = QRCode::from_string(URL.to_string());
     assert!(qr.colorize(Rgba([0, 102, 204, 255])).dimensions().0 > 0);
     assert_eq!(qr.resize(80, 40).dimensions(), (80, 40));
+
+    // A non-square shape leaves gaps inside each dark module, exercising the
+    // `is_inside_shape == false` branch in both colorize and resize.
+    let circ = QRCode::from_string(URL.to_string()).with_shape(ModuleShape::Circle);
+    assert!(circ.colorize(Rgba([10, 20, 30, 255])).dimensions().0 > 0);
+    assert_eq!(circ.resize(60, 60).dimensions(), (60, 60));
 }
 
 // --- Logos / watermarks / art ---------------------------------------------
@@ -110,6 +121,11 @@ fn overlay_watermark_and_art() {
     logo.put_pixel(0, 0, Rgba([0, 0, 0, 0]));
     let overlaid = qr.overlay_image(&logo);
     assert!(overlaid.width() > 24);
+
+    // An oversized overlay spills past the canvas, exercising the bounds-clamp
+    // (`px < dim && py < dim` == false) branch.
+    let big: RgbaImage = ImageBuffer::from_pixel(4000, 4000, Rgba([1, 2, 3, 255]));
+    let _ = qr.overlay_image(&big);
 
     // Static watermark mutates the passed image in place.
     let mut canvas = qr.to_png(200);
@@ -202,4 +218,7 @@ fn wasm_bindings_cover_every_branch() {
     assert!(qr.to_svg(128).contains("<svg"));
     assert!(!qr.to_png_bytes(128).is_empty());
     assert!(!qr.to_jpg(128).is_empty());
+    // width 0 -> inner Err -> the binding's `unwrap_or_default` returns empty.
+    assert!(qr.to_png_bytes(0).is_empty());
+    assert!(qr.to_jpg(0).is_empty());
 }

--- a/tests/qr.rs
+++ b/tests/qr.rs
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn test_to_gif() {
         let qrcode = QRCode::from_string(URL.to_string());
-        let qrcode_gif = qrcode.to_gif(512);
+        let qrcode_gif = qrcode.to_gif(512).unwrap();
         // GIF magic bytes: GIF89a or GIF87a
         assert!(qrcode_gif.len() > 6);
         assert_eq!(&qrcode_gif[..3], b"GIF");
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn test_to_jpg() {
         let qrcode = QRCode::from_string(URL.to_string());
-        let qrcode_jpg = qrcode.to_jpg(512);
+        let qrcode_jpg = qrcode.to_jpg(512).unwrap();
         // JPEG magic bytes: FF D8 FF
         assert!(qrcode_jpg.len() > 3);
         assert_eq!(&qrcode_jpg[..2], &[0xFF, 0xD8]);
@@ -131,8 +131,8 @@ mod tests {
     #[test]
     fn test_qr_code_from_png() {
         let data = vec![0x61, 0x62, 0x63];
-        let result = qr_code_to!(data.clone(), "png", 512);
-        // qr_code_to! now returns Vec<u8> (PNG-encoded bytes)
+        let result = qr_code_to!(data.clone(), "png", 512).unwrap();
+        // qr_code_to! now returns Result<Vec<u8>, _> (PNG-encoded bytes)
         assert!(!result.is_empty());
         // Verify PNG magic bytes
         assert_eq!(&result[..4], &[0x89, 0x50, 0x4E, 0x47]);
@@ -244,21 +244,21 @@ mod tests {
     #[test]
     fn test_jpg_magic_bytes() {
         let qr = QRCode::from_string("test".to_string());
-        let jpg = qr.to_jpg(64);
+        let jpg = qr.to_jpg(64).unwrap();
         assert_eq!(&jpg[..2], &[0xFF, 0xD8]);
     }
 
     #[test]
     fn test_gif_magic_bytes() {
         let qr = QRCode::from_string("test".to_string());
-        let gif = qr.to_gif(64);
+        let gif = qr.to_gif(64).unwrap();
         assert_eq!(&gif[..3], b"GIF");
     }
 
     #[test]
     fn test_png_bytes_magic() {
         let qr = QRCode::from_string("test".to_string());
-        let png = qr.to_png_bytes(64);
+        let png = qr.to_png_bytes(64).unwrap();
         assert_eq!(&png[..4], &[0x89, 0x50, 0x4E, 0x47]);
     }
 


### PR DESCRIPTION
Follow-up to the v0.0.6 release: takes coverage from 99.76% region to a **literal 100%** (regions, functions, and lines).

## Change (breaking, pre-1.0)
`to_png_bytes` / `to_jpg` / `to_jpg_with_quality` / `to_gif` now return **`Result<Vec<u8>, image::ImageError>`** instead of panicking via `.expect(...)`. PNG/GIF share a private `encode_bytes(format)` helper.

This makes the formerly-unreachable encoder panic arms into *testable* error paths (a `width` of 0 is an invalid PNG/JPEG size), and the new tests also cover the previously-untaken branches in `colorize`/`resize` (non-square `is_inside_shape == false`) and `overlay_image` (oversized-overlay bounds clamp).

## Coverage
```
regions    100.00%
functions  100.00%
lines      100.00%
```

## Callers updated
`qr_code_to!` macro (+ doctest), WASM bindings (`unwrap_or_default`, both arms tested), the `formats`/`macros` examples, and the README's format block.

## Verification
`cargo test --all-features`, `clippy --all-targets --all-features` (0), `fmt --check`, and `cargo doc -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)