### PR TITLE
chore(release): v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the crate is pre-1.0, minor breaking changes may land in patch releases.
 
-## [0.0.6] - Unreleased
+## [0.0.6] - 2026-06-25
 
 ### Added
 


### PR DESCRIPTION
Datestamps the CHANGELOG for the v0.0.6 release. Tag to follow.