### PR TITLE
fix(release): valid crates.io category slugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["QRC"]
-categories = ["Algorithms", "Encoding", "Images", "Rendering", "Visualization"]
+categories = ["algorithms", "encoding", "multimedia::images", "rendering", "visualization"]
 description = """
 A Rust library for generating and manipulating QR code images in various formats
 """


### PR DESCRIPTION
crates.io rejected the v0.0.6 publish with a 400 (invalid category slugs). Switches to the canonical lowercase slugs so the publish succeeds.